### PR TITLE
sweet: Switch to auto-brightness model from redfin

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -113,7 +113,7 @@
 
          This array should be equal in size to config_screenBrightnessBacklight -->
     <array name="config_screenBrightnessNits">
-        <item>1</item>   <!-- index 1 -->
+        <item>2</item>   <!-- index 1 -->
         <item>500</item>  <!-- index 2 -->
     </array>
 

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -41,61 +41,23 @@
     <integer-array name="config_autoBrightnessLevels">
         <item>1</item>
         <item>2</item>
+        <item>3</item>
         <item>4</item>
-        <item>6</item>
         <item>8</item>
-        <item>10</item>
-        <item>15</item>
+        <item>12</item>
         <item>20</item>
-        <item>25</item>
-        <item>30</item>
-        <item>35</item>
-        <item>40</item>
-        <item>45</item>
-        <item>50</item>
+        <item>33</item>
         <item>55</item>
-        <item>60</item>
-        <item>65</item>
-        <item>70</item>
-        <item>75</item>
-        <item>80</item>
-        <item>85</item>
         <item>90</item>
-        <item>95</item>
-        <item>100</item>
-        <item>120</item>
-        <item>140</item>
-        <item>160</item>
-        <item>180</item>
-        <item>200</item>
-        <item>220</item>
-        <item>240</item>
-        <item>260</item>
-        <item>280</item>
-        <item>300</item>
-        <item>320</item>
-        <item>340</item>
-        <item>360</item>
-        <item>380</item>
-        <item>400</item>
-        <item>420</item>
-        <item>440</item>
-        <item>460</item>
-        <item>480</item>
-        <item>500</item>
-        <item>700</item>
-        <item>900</item>
-        <item>1100</item>
-        <item>1300</item>
-        <item>1500</item>
-        <item>1700</item>
-        <item>1900</item>
-        <item>2000</item>
-        <item>2500</item>
-        <item>3000</item>
-        <item>3500</item>
-        <item>4000</item>
-        <item>4500</item>
+        <item>148</item>
+        <item>245</item>
+        <item>403</item>
+        <item>665</item>
+        <item>1097</item>
+        <item>1808</item>
+        <item>2981</item>
+        <item>5000</item>
+        <item>10000</item>
     </integer-array>
 
     <!-- Array of desired screen brightness in nits corresponding to the lux values
@@ -112,64 +74,26 @@
          array. The brightness values must be non-negative and non-decreasing. This must be
          overridden in platform specific overlays -->
     <array name="config_autoBrightnessDisplayValuesNits">
-        <item>5</item>
-        <item>5</item>
-        <item>5</item>
-        <item>17</item>
-        <item>24</item>
-        <item>31</item>
-        <item>34</item>
-        <item>46</item>
-        <item>59</item>
-        <item>76</item>
-        <item>81</item>
-        <item>82</item>
-        <item>82</item>
-        <item>82</item>
-        <item>83</item>
-        <item>83</item>
-        <item>83</item>
-        <item>84</item>
-        <item>84</item>
-        <item>85</item>
-        <item>85</item>
-        <item>85</item>
-        <item>85</item>
-        <item>86</item>
-        <item>86</item>
-        <item>87</item>
-        <item>89</item>
-        <item>90</item>
-        <item>91</item>
-        <item>93</item>
-        <item>94</item>
-        <item>96</item>
-        <item>97</item>
-        <item>99</item>
-        <item>100</item>
-        <item>101</item>
-        <item>104</item>
-        <item>105</item>
-        <item>106</item>
-        <item>108</item>
-        <item>109</item>
-        <item>111</item>
-        <item>112</item>
-        <item>114</item>
-        <item>116</item>
-        <item>137</item>
-        <item>157</item>
-        <item>180</item>
-        <item>205</item>
-        <item>226</item>
-        <item>257</item>
-        <item>280</item>
-        <item>295</item>
-        <item>369</item>
-        <item>434</item>
-        <item>517</item>
-        <item>520</item>
-        <item>520</item>
+        <item>5.139055</item>
+        <item>9.962019</item>
+        <item>18.34823</item>
+        <item>21.550682</item>
+        <item>24.016779</item>
+        <item>30.621622</item>
+        <item>35.094864</item>
+        <item>41.224964</item>
+        <item>47.67607</item>
+        <item>55.730022</item>
+        <item>66.241264</item>
+        <item>79.67614</item>
+        <item>98.04727</item>
+        <item>125.1222</item>
+        <item>161.68752</item>
+        <item>208.48856</item>
+        <item>264.82214</item>
+        <item>327.89743</item>
+        <item>401.16766</item>
+        <item>500.0</item>
     </array>
 
     <!-- An array describing the screen's backlight values corresponding to the brightness
@@ -189,8 +113,8 @@
 
          This array should be equal in size to config_screenBrightnessBacklight -->
     <array name="config_screenBrightnessNits">
-        <item>5</item>   <!-- index 1 -->
-        <item>520</item>  <!-- index 2 -->
+        <item>1</item>   <!-- index 1 -->
+        <item>500</item>  <!-- index 2 -->
     </array>
 
     <!-- Screen brightness used to dim the screen when the user activity
@@ -212,8 +136,8 @@
          when adapting to brighter or darker environments.  This parameter controls how quickly
          brightness changes occur in response to an observed change in light level that exceeds the
          hysteresis threshold. -->
-    <integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
-    <integer name="config_autoBrightnessDarkeningLightDebounce">1000</integer>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">4000</integer>
 
     <!-- The bounding path of the cutout region of the main built-in display.
          Must either be empty if there is no cutout region, or a string that is parsable by


### PR DESCRIPTION
all values are from redfin except maximum of nits which is adapted from MIUI where it was set to 500 